### PR TITLE
Fixes issue allowing loggers to remain open after being removed

### DIFF
--- a/XLFacility/Core/XLFacility.m
+++ b/XLFacility/Core/XLFacility.m
@@ -176,11 +176,11 @@ static void _ExitHandler() {
 }
 
 - (void)removeAllLoggers {
+  [self _closeAllLoggers];
+
   dispatch_sync(_lockQueue, ^{
     [_loggers removeAllObjects];
   });
-
-  [self _closeAllLoggers];
 }
 
 @end


### PR DESCRIPTION
The `_closeAllLoggers` function iterates over the `_loggers` set variable in order to call `performClose` on each logger, but the `removeAllLoggers` function clears that set prior to calling `_closeAllLoggers`, preventing it from closing any of the loggers that were removed.