### PR TITLE
Fix deadlock

### DIFF
--- a/XLFacility.xcodeproj/project.pbxproj
+++ b/XLFacility.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
+			usesTabs = 0;
 		};
 		E26DC16819E8494700C68DDC /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Conditions for the deadlock:
* Emit a log with level >= kXLLogLevel_Error from the main thread
* Have a logger that post a notification
* Have an observer for that notification registered on the main queue: [NSNotificationCenter.defaultCenter addObserverForName:notificationName object:nil queue:NSOperationQueue.mainQueue usingBlock:…]

Fix for the deadlock: always using `dispatch_async` instead of `dispatch_sync` on the lock queue for `[self _logRecord:record]`